### PR TITLE
[PS-19580]: odd-jobs retries

### DIFF
--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -18,6 +18,7 @@ createJobTableQuery tname = "CREATE TABLE " <> tname <>
   ", payload jsonb not null" <>
   ", last_error jsonb null" <>
   ", attempts int not null default 0" <>
+  ", max_retries int null" <>
   ", locked_at timestamp with time zone null" <>
   ", locked_by text null" <>
   ", constraint incorrect_locking_info CHECK ((status <> 'locked' and locked_at is null and locked_by is null) or (status = 'locked' and locked_at is not null and locked_by is not null))" <>

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -172,6 +172,7 @@ data Job = Job
   , jobPayload :: Aeson.Value
   , jobLastError :: Maybe Value
   , jobAttempts :: Int
+  , jobMaxRetries :: Maybe Int
   , jobLockedAt :: Maybe UTCTime
   , jobLockedBy :: Maybe JobRunnerName
   } deriving (Eq, Show, Generic)
@@ -211,6 +212,7 @@ instance FromRow Job where
     <*> field -- payload
     <*> field -- lastError
     <*> field -- attempts
+    <*> field -- retries
     <*> field -- lockedAt
     <*> field -- lockedBy
 


### PR DESCRIPTION
https://ticket.simspace.com/browse/PS-19580

This PR adds a field to `Job` for optional retries. `jobMaxRetries` allows you to override the maximum number of retries set for a specific job instead of using the value set in the config or the default config value.

This PR was tested by using this branch while running through the workflow of scheduling scenarios to auto start. More on testing here: https://github.com/Simspace/portal-suite/pull/4188